### PR TITLE
[Api] Add DELETE user and requests / user utils

### DIFF
--- a/api/src/features/users/delete.feature
+++ b/api/src/features/users/delete.feature
@@ -1,0 +1,46 @@
+Feature: Delete user
+
+  As a consumer of the Monarch API,
+  I want to be able to delete a user.
+
+  Background:
+    Given I seed "users"
+    And I get a token
+
+
+  Scenario: Delete user
+    When DELETE "/users/1"
+    Then response status code is 201
+    And response body is undefined
+
+
+  Scenario: Delete user with missing user id
+    When DELETE "/users"
+    Then response status code is 404
+
+
+  Scenario: Delete nonexisting user
+    When DELETE "/users/1337"
+    Then response status code is 404
+    And response body matches
+      """
+      {
+        error: "Not found",
+        message: "User with id "1" does not exist",
+        statusCode: 404,
+      }
+      """
+
+
+  Scenario: Delete user with unexpected error
+    Given "users" table is dropped
+    When DELETE "/users/1"
+    Then response status code is 500
+    And response body matches
+      """
+      {
+        error: _.isString,
+        message: "An internal server error occurred",
+        statusCode: 500,
+      }
+      """

--- a/api/src/features/users/delete.feature
+++ b/api/src/features/users/delete.feature
@@ -14,11 +14,6 @@ Feature: Delete user
     And response body is undefined
 
 
-  Scenario: Delete user with missing user id
-    When DELETE "/users"
-    Then response status code is 404
-
-
   Scenario: Delete nonexisting user
     When DELETE "/users/1337"
     Then response status code is 404

--- a/api/src/features/users/delete.feature
+++ b/api/src/features/users/delete.feature
@@ -8,21 +8,21 @@ Feature: Delete user
     And I get a token
 
 
-  Scenario: Delete user
+  Scenario: Delete self
     When DELETE "/users/1"
-    Then response status code is 201
+    Then response status code is 204
     And response body is undefined
 
 
-  Scenario: Delete nonexisting user
+  Scenario: Delete another user
     When DELETE "/users/1337"
-    Then response status code is 404
+    Then response status code is 403
     And response body matches
       """
       {
-        error: "Not found",
-        message: "User with id "1" does not exist",
-        statusCode: 404,
+        error: "Forbidden",
+        message: "This action may only be performed by the same user",
+        statusCode: 403,
       }
       """
 

--- a/api/src/handlers/users.js
+++ b/api/src/handlers/users.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 const bcrypt = require('bcrypt');
 const boom = require('boom');
 const joi = require('joi');
+const {enforceSelfActionOnly} = require('../utils/user');
 
 const hash = Promise.promisify(bcrypt.hash);
 
@@ -12,17 +13,19 @@ const users = {
   post: {}
 };
 
+users.delete.config = {
+  pre: [enforceSelfActionOnly],
+};
+
 users.delete.handler = async (request, reply) => {
   const {id} = request.params;
 
   try {
-    await request.knex('users').delete().where({id});
+    await request.knex('users').where({id}).delete();
+    reply.response().code(204);
   } catch (error) {
-    // reply(boom.notFound(`User with id "${id}" does not exist`));
     reply(boom.badImplementation(`Failed to delete user with id "${id}"`));
   }
-
-  reply.response().code(201);
 };
 
 users.get.handler = async (request, reply) => {

--- a/api/src/handlers/users.js
+++ b/api/src/handlers/users.js
@@ -12,7 +12,18 @@ const users = {
   post: {}
 };
 
-users.delete.handler = () => {};
+users.delete.handler = async (request, reply) => {
+  const {id} = request.params;
+
+  try {
+    await request.knex('users').delete().where({id});
+  } catch (error) {
+    // reply(boom.notFound(`User with id "${id}" does not exist`));
+    reply(boom.badImplementation(`Failed to delete user with id "${id}"`));
+  }
+
+  reply.response().code(201);
+};
 
 users.get.handler = async (request, reply) => {
   const {id} = request.params;

--- a/api/src/routes/users.js
+++ b/api/src/routes/users.js
@@ -18,6 +18,7 @@ module.exports = [
     path: '/v1/users'
   },
   {
+    config: users.delete.config,
     handler: users.delete.handler,
     method: 'DELETE',
     path: '/v1/users/{id}'

--- a/api/src/utils/__tests__/request.test.js
+++ b/api/src/utils/__tests__/request.test.js
@@ -1,0 +1,25 @@
+const requestUtils = require('../request');
+const jwt = require('jsonwebtoken');
+
+const mockTokenPayload = {
+  joke: 'A witticism, a gag, a bon mot, a fluctuation of words concluding' +
+    'with a trick-Shut up Data.'
+};
+
+const mockRequest = {
+  headers: {
+    authorization: `Bearer ${jwt.sign(
+      mockTokenPayload,
+      'secret',
+      {noTimestamp: true}
+    )}`
+  }
+};
+
+describe('requestUtils', function() {
+  describe('getTokenFromRequest', function() {
+    it('should return the decoded token from the provided request', function() {
+      expect(requestUtils.getTokenFromRequest(mockRequest)).to.eql(mockTokenPayload);
+    });
+  });
+});

--- a/api/src/utils/__tests__/user.test.js
+++ b/api/src/utils/__tests__/user.test.js
@@ -1,0 +1,68 @@
+const mock = require('mock-require');
+const sinon = require('sinon');
+
+const sandbox = sinon.createSandbox();
+const mockRequestUtils = {getTokenFromRequest: sandbox.stub()};
+const mockBoom = {forbidden: sandbox.stub()};
+
+mock('../request', mockRequestUtils);
+mock('boom', mockBoom);
+const userUtils = require('../user');
+
+describe('userUtils', function() {
+  after(function() {
+    mock.stopAll();
+  });
+
+  afterEach(function() {
+    sandbox.reset();
+  });
+
+  describe('enforceSelfActionOnly', function() {
+    const mockRequest = {params: {id: 0}};
+    const mockReply = sandbox.spy();
+    mockReply.continue = sandbox.spy();
+
+    context('when the authenticated user id matches the id parameter value', function() {
+      before(function() {
+        mockRequestUtils.getTokenFromRequest
+          .withArgs(mockRequest)
+          .returns({id: 0});
+
+        userUtils.enforceSelfActionOnly(mockRequest, mockReply);
+      });
+
+      it('should continue the response', function() {
+        expect(mockReply.continue).to.be.called;
+      });
+
+      it('should not call reply directly', function() {
+        expect(mockReply).to.not.be.called;
+      });
+    });
+
+    context('when the authenticated user id does not match the id parameter value', function() {
+      const forbiddenError = "Ah ah ah! You didn't say the magic word!";
+
+      before(function() {
+        mockRequestUtils.getTokenFromRequest
+          .withArgs(mockRequest)
+          .returns({id: 1});
+
+        mockBoom.forbidden
+          .withArgs('This action may only be performed by the same user')
+          .returns(forbiddenError);
+
+        userUtils.enforceSelfActionOnly(mockRequest, mockReply);
+      });
+
+      it('should respond with forbidden', function() {
+        expect(mockReply).to.be.calledWith(forbiddenError);
+      });
+
+      it('should not continue', function() {
+        expect(mockReply.continue).to.not.be.called;
+      });
+    });
+  });
+});

--- a/api/src/utils/request.js
+++ b/api/src/utils/request.js
@@ -1,0 +1,11 @@
+const jwt = require('jsonwebtoken');
+
+const BEARER_TOKEN_LENGTH = 'Bearer '.length;
+
+const requestUtils = {};
+
+requestUtils.getTokenFromRequest = (request) => jwt.decode(
+  request.headers.authorization.substr(BEARER_TOKEN_LENGTH)
+);
+
+module.exports = requestUtils;

--- a/api/src/utils/user.js
+++ b/api/src/utils/user.js
@@ -1,0 +1,18 @@
+const boom = require('boom');
+const {getTokenFromRequest} = require('./request');
+
+const userUtils = {};
+
+userUtils.enforceSelfActionOnly = (request, reply) => {
+  const tokenId = parseInt(getTokenFromRequest(request).id);
+  const requestId = parseInt(request.params.id);
+
+  if (requestId !== tokenId) {
+    reply(boom.forbidden('This action may only be performed by the same user'));
+    return;
+  }
+
+  reply.continue();
+};
+
+module.exports = userUtils;


### PR DESCRIPTION
## Changes
* Add `getTokenFromRequest` util in `requests.js`
* Add `enforceSelfActionOnly` util in `user.js`
* Implement `DELETE` `/user`

![](https://media.giphy.com/media/3oKIPwoeGErMmaI43S/giphy.gif)
