### PR TITLE
[Api] Remove duplicate reply calls from user.feature

### DIFF
--- a/api/src/handlers/users.js
+++ b/api/src/handlers/users.js
@@ -31,7 +31,6 @@ users.getAll.handler = () => {};
 users.post.handler = async (request, reply) => {
   const {email, password} = request.payload;
   const {saltRounds} = request.config.get('auth');
-  const userCreatedMessage = `User created for "${email}"`;
   let hashedPassword;
 
   try {
@@ -56,13 +55,10 @@ users.post.handler = async (request, reply) => {
     reply.response().code(201);
   } catch (error) {
     if (error.message.indexOf('users_email_unique') > -1) {
-      reply.response().code(201);
+      return reply.response().code(201);
     }
 
     reply(boom.badImplementation());
-    throw error;
-  } finally {
-    request.log(['info'], userCreatedMessage);
   }
 };
 


### PR DESCRIPTION
## Changes
* Remove superfluous logging from `user.post` handler
* Only allow reply to be called once

![](https://media.giphy.com/media/w3gxkfKfIKaXu/giphy.gif)
