### PR TITLE
Add Preliminary Signup Page Scaffolding

### DIFF
--- a/ui/src/components/signup/index.js
+++ b/ui/src/components/signup/index.js
@@ -1,0 +1,56 @@
+import FullLogo from 'icons/full_logo';
+import PropTypes from 'prop-types';
+import React from 'react';
+import withField from 'hocs/with_field';
+import {Field} from 'redux-form';
+import {PrimaryButton} from 'components/buttons';
+import {InlineErrorNotification} from 'components/inline_notifications';
+
+const InputField = withField('input');
+
+const Steps = [
+  <Field
+    component={InputField}
+    label='Email'
+    name='email'
+    type='email' />,
+  <Field
+    component={InputField}
+    label='Username'
+    name='username'
+    type='text' />,
+  <Field
+    component={InputField}
+    label='Password'
+    name='password'
+    type='password' />
+];
+
+function getStepButtonLabel(currentIndex) {
+  if (currentIndex == Steps.length - 1) {
+    return "Submit";
+  }
+  return "Next";
+}
+
+const Signup = ({error, handleSubmit, step, submitting}) =>
+  <div className='signup-form-wrapper'>
+    <FullLogo />
+    <form className='signup-form' noValidate onSubmit={handleSubmit}>
+      {error && <InlineErrorNotification message={error} />}
+      {Steps[step]}
+      <PrimaryButton
+        disabled={submitting}
+        text={getStepButtonLabel(step)}
+        type='submit'/>
+    </form>
+  </div>;
+
+Signup.propTypes = {
+  error: PropTypes.string,
+  handleSubmit: PropTypes.func.isRequired,
+  step: PropTypes.number,
+  submitting: PropTypes.bool
+};
+
+export default Signup;

--- a/ui/src/constants/actions.js
+++ b/ui/src/constants/actions.js
@@ -4,5 +4,11 @@ export default {
     LOGIN_REQUEST: 'auth/LOGIN_REQUEST',
     LOGIN_FAILURE: 'auth/LOGIN_FAILURE',
     LOGIN_SUCCESS: 'auth/LOGIN_SUCCESS'
+  },
+  Singup: {
+    NEXT_STEP: 'signup/NEXT_STEP',
+    CREATE_REQUEST: 'singup/CREATE_REQUEST',
+    CREATE_FAILURE: 'singup/CREATE_FAILURE',
+    CREATE_SUCCESS: 'singup/CREATE_SUCCESS'
   }
 };

--- a/ui/src/containers/signup/actions.js
+++ b/ui/src/containers/signup/actions.js
@@ -1,0 +1,9 @@
+import ActionTypes from 'constants/actions';
+import ApiPaths from 'constants/api_paths';
+
+const Actions = {};
+
+ActionTypes.nextStep = (payload) => ({
+  type: ActionTypes.Signup.NEXT_STEP,
+  payload
+});

--- a/ui/src/containers/signup/index.js
+++ b/ui/src/containers/signup/index.js
@@ -1,0 +1,34 @@
+import SignupActions from "./actions";
+import Signup from "components/signup";
+import validate from "./validate";
+import {connect} from "react-redux";
+import {reduxForm, stopSubmit, SubmissionError} from "redux-from";
+
+const FORM_NAME = "signup";
+const SignupForm = reduxForm({
+  form: FORM_NAME,
+  initialValues: {
+    email: '',
+    password: '',
+    username: ''
+  },
+  persistentSubmitErrors: true
+})(Signup);
+
+const mapToProps = (state) => ({
+  step: state.signup.step
+});
+
+const actionAsProps = dispatch => ({
+  onSubmit: form => {
+    const validationErrors = validate(form);
+    if (Object.keys(validationErrors).length) {
+      return Promise.reject(new SubmissionError(validationErrors));
+    }
+
+    dispatch(stopSubmit(FORM_NAME, {}));
+    dispatch(SignupActions.nextStep(form));
+  }
+})
+
+export default connect(mapToProps, actionAsProps)(LoginForm)

--- a/ui/src/containers/signup/signup.scss
+++ b/ui/src/containers/signup/signup.scss
@@ -1,0 +1,47 @@
+@import '~theme/vars';
+
+.signup-form-wrapper {
+  margin-top: $space;
+  width: 100%;
+
+  .svg-full-logo {
+    fill: $white;
+    margin-bottom: $space;
+    width: 80%;
+  }
+
+  .signup-form {
+    background: $white;
+    padding: $space-xlarge;
+
+    .field {
+      &:last-of-type {
+        margin-bottom: $space-xlarge;
+      }
+    }
+  }
+
+  .field {
+    width: 100%;
+
+    .input {
+      width: 100%;
+    }
+  }
+
+  .button {
+    &.primary {
+      width: 100%;
+    }
+  }
+
+  // Corresponds to width value
+  @media only screen and (min-width: 385px) {
+    left: 50%;
+    margin-top: 0;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: $space * 24;
+  }
+}

--- a/ui/src/containers/signup/validate.js
+++ b/ui/src/containers/signup/validate.js
@@ -1,0 +1,35 @@
+const validators = {
+  email: (errors, value) => {
+    const [prefix = '', suffix = ''] = value.split('@')
+    const hasDomain = suffix.split('.').length >= 2
+    if (prefix && hasDomain) {
+      return errors['email'] = 'Email does not appear to have the proper format.';
+    }
+    return errors;
+  },
+  password: (errors, value) => {
+    if (value.length < 20) {
+      return errors['password'] = 'Password does not meet minimum length.'
+    }
+  },
+  username: (errors, value) => {
+    if (value.length < 3) {
+      return errors['username'] = 'Username does not meet minimum length.'
+    }
+  }
+};
+
+const validate = values => {
+  const keys = Object.keys(values);
+  return keys.reduce(
+    (errors, valueKey) => {
+      if (values[valueKey] && !validators[valueKey]) return errors;
+      if (values[valueKey]) return validate[valueKey](errors, values[valueKey]);
+      errors[valueKey] = 'Required';
+      return errors;
+    },
+    {}
+  );
+};
+
+export default validate;

--- a/ui/src/reducers/__tests__/createReducer.test.js
+++ b/ui/src/reducers/__tests__/createReducer.test.js
@@ -1,0 +1,34 @@
+import createReducer from '../createReducer';
+import sinon from 'sinon';
+
+const sandbox = sinon.createSandbox();
+const EXAMPLE_ACTION = {type: "EXAMPLE_ACTION_NAME", payload: 123}; 
+const INITIAL_STATE = {example1: 'test1', example2: 'test2'};
+const FINAL_STATE = {example1: 'modified1', example2: 'modified2'};
+
+describe('createReducer', function() {
+  let reducer;
+  beforeEach(function() {
+    const handlers = {
+     [EXAMPLE_ACTION.type]: sandbox.stub().returns(FINAL_STATE)
+    }
+    reducer = createReducer(INITIAL_STATE, handlers);
+  });
+
+  afterEach(function() {
+    sandbox.resetHistory();
+  });
+
+  context('when a defined action is called', function() {
+    it('it should invoke the provided handler', function() {
+      expect(reducer(INITIAL_STATE, EXAMPLE_ACTION)).to.eq(FINAL_STATE);
+    });
+  });
+
+  context('when an udefined action is called', function() {
+    const UNDEFINED_ACTION = {type: "UNDEFINED_ACTION", payload: 456}; 
+    it('it should not modify the state', function() {
+      expect(reducer(INITIAL_STATE, UNDEFINED_ACTION)).to.eq(INITIAL_STATE);
+    });
+  });
+});

--- a/ui/src/reducers/auth.js
+++ b/ui/src/reducers/auth.js
@@ -1,15 +1,6 @@
 import ActionTypes from 'constants/actions';
 import LocalStorageConstants from 'constants/local_storage';
-
-function createReducer(initialState, handlers) {
-  return (state = initialState, action = {}) => {
-    if (handlers.hasOwnProperty(action.type)) {
-      return handlers[action.type](state, action);
-    } else {
-      return state;
-    }
-  };
-}
+import createReducer from "./createReducer";
 
 const initialState = {isAuthenticated: false};
 const {TOKEN_KEY} = LocalStorageConstants;

--- a/ui/src/reducers/createReducer.js
+++ b/ui/src/reducers/createReducer.js
@@ -1,0 +1,9 @@
+export default function createReducer(initialState, handlers) {
+  return (state = initialState, action = {}) => {
+    if (handlers.hasOwnProperty(action.type)) {
+      return handlers[action.type](state, action);
+    } else {
+      return state;
+    }
+  };
+}

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,4 +1,5 @@
 import auth from './auth';
+import signup from './signup';
 import {reducer as form} from 'redux-form';
 
-export default {auth, form};
+export default {auth, form, signup};

--- a/ui/src/reducers/signup.js
+++ b/ui/src/reducers/signup.js
@@ -1,0 +1,17 @@
+import ActionTypes from 'constants/actions';
+import LocalStorageConstants from 'constants/local_storage';
+import createReducer from "./createReducer";
+
+const initialState = {
+  email: '',
+  password: '',
+  step: 0,
+  username: ''
+};
+
+export default createReducer(initialState, {
+  [ActionTypes.Signup.NEXT_STEP]: (state, {payload}) => {
+    const step = state.step + 1;
+    return Object.assign({}, state, step, payload);
+  },
+});


### PR DESCRIPTION
## Changes
* Add Signup Components, Actions, and Reducers.
* Move `createReducer` to its own file to enable reuse.
  * Add test for `createReducer`.

## Notes
* _This is not fully fleshed out yet._
* Hoping to use this as a reference point to talk about related changes that may be required or nice to have.