### PR TITLE
Use UUIDs instead of integer for primary key in users table

### DIFF
--- a/service/env/development/seeds/user_account.js
+++ b/service/env/development/seeds/user_account.js
@@ -1,16 +1,16 @@
 const Promise = require('bluebird');
 const bcrypt = require('bcrypt');
+const uuidv4 = require('uuid/v4');
 
 const {saltRounds} = require('../config.json').auth;
 const hash = Promise.promisify(bcrypt.hash);
 
 exports.seed = async knex => {
-  const users = [
-    {
-      email: 'jill@abc.com',
-      password: await hash('password', saltRounds)
-    }
-  ];
+  const users = [{
+    email: 'jill@abc.com',
+    id: uuidv4(),
+    password: await hash('password', saltRounds)
+  }];
 
-  return knex('user_account').insert(users);
+  await knex('user_account').insert(users);
 };

--- a/service/env/test/seeds/user_account.js
+++ b/service/env/test/seeds/user_account.js
@@ -8,6 +8,7 @@ exports.seed = async knex => {
   const users = [
     {
       email: 'frankjaeger@foxhound.com',
+      id: '10ba038e-48da-487b-96e8-8d3b99b6d18a',
       password: await hash('password', saltRounds)
     }
   ];

--- a/service/src/features/location/search.feature
+++ b/service/src/features/location/search.feature
@@ -58,7 +58,6 @@ Feature: User can search for a location
       }
       """
 
-  @Only
   Scenario: Third-party geocoding API is down
     Given the third party geocoding API is down
     When POST "/location/search"

--- a/service/src/features/step_definitions/hooks.js
+++ b/service/src/features/step_definitions/hooks.js
@@ -48,7 +48,6 @@ Before(async function() {
 Before(function() {
   locationGatewayMock.start({
     cacheDir: path.resolve('src/features/fixtures/here'),
-    logLevel: 'debug',
     port: 9000,
     queryParameterBlacklist: 'app_code,app_id',
     serverBaseUrl: 'https://autocomplete.geocoder.api.here.com'

--- a/service/src/features/step_definitions/user.js
+++ b/service/src/features/step_definitions/user.js
@@ -2,19 +2,19 @@ const matchPattern = require('lodash-match-pattern');
 const {Given, Then} = require('cucumber');
 const {expect} = require('chai');
 
-Given('{ordinalInt} user matches', async function(id, json) {
+Given('{string} user matches', async function(id, json) {
   const [user] = await this.knex('user_account').select().where({id});
 
   const userResultMatchesPattern = matchPattern(user, json);
   if (userResultMatchesPattern) { throw new Error(userResultMatchesPattern); }
 });
 
-Given('I store the {ordinalInt} user', async function(id) {
+Given('I store the {string} user', async function(id) {
   const [user] = await this.knex('user_account').select().where({id});
   this.activeUser = user;
 });
 
-Then('{ordinalInt} user remains unchanged', async function(id) {
+Then('{string} user remains unchanged', async function(id) {
   const [user] = await this.knex('user_account').select().where({id});
   expect(user).to.eql(this.activeUser);
 });

--- a/service/src/features/users/create.feature
+++ b/service/src/features/users/create.feature
@@ -25,7 +25,7 @@ Feature: Create user
         bio: null,
         createDate: _.isDate,
         email: "testemail@domain.com",
-        id: 1,
+        id: _.isUuid,
         modifyDate: _.isDate,
         password: _.isSize|60
         ...

--- a/service/src/features/users/delete.feature
+++ b/service/src/features/users/delete.feature
@@ -9,7 +9,7 @@ Feature: Delete user
 
 
   Scenario: Delete self
-    When DELETE "/users/1"
+    When DELETE "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
     Then response status code is 204
     And response body is undefined
 
@@ -29,7 +29,7 @@ Feature: Delete user
 
   Scenario: Delete user with unexpected error
     Given "user_account" table is dropped
-    When DELETE "/users/1"
+    When DELETE "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
     Then response status code is 500
     And response body matches
       """

--- a/service/src/features/users/get.feature
+++ b/service/src/features/users/get.feature
@@ -9,7 +9,7 @@ Feature: Get user
 
 
   Scenario: Get self
-    When GET "/users/1"
+    When GET "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
     Then response status code is 200
     And response body matches
       """
@@ -17,7 +17,7 @@ Feature: Get user
         bio: null,
         createDate: _.isDateString,
         email: "frankjaeger@foxhound.com",
-        id: 1,
+        id: "10ba038e-48da-487b-96e8-8d3b99b6d18a",
         modifyDate: _.isDateString,
         password: _.isSize|60
       }
@@ -39,7 +39,7 @@ Feature: Get user
 
   Scenario: Get a user with unexpected error
     When "user_account" table is dropped
-    And GET "/users/1"
+    And GET "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
     Then response status code is 500
     And response body matches
       """

--- a/service/src/features/users/patch.feature
+++ b/service/src/features/users/patch.feature
@@ -9,14 +9,14 @@ Feature: Patch user
 
 
   Scenario: Update self
-    Given 1st user matches
+    Given "10ba038e-48da-487b-96e8-8d3b99b6d18a" user matches
       """
       {
         modifyDate: _.isSetAsMemo|modifyDate,
         ...
       }
       """
-    When PATCH "/users/1"
+    When PATCH "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
       """
       {
         "bio": "More...MORE!!"
@@ -24,7 +24,7 @@ Feature: Patch user
       """
     Then response status code is 200
     And response body is undefined
-    Then 1st user matches
+    Then "10ba038e-48da-487b-96e8-8d3b99b6d18a" user matches
       """
       {
         bio: 'More...MORE!!',
@@ -35,17 +35,17 @@ Feature: Patch user
 
 
   Scenario: Update self with empty object
-    Given I store the 1st user
-    When PATCH "/users/1"
+    Given I store the "10ba038e-48da-487b-96e8-8d3b99b6d18a" user
+    When PATCH "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
       """
       {}
       """
     Then response status code is 200
-    And 1st user remains unchanged
+    And "10ba038e-48da-487b-96e8-8d3b99b6d18a" user remains unchanged
 
 
   Scenario Outline: Update self with invalid payload
-    When PATCH "/users/1"
+    When PATCH "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
       """
       {
         "<KEY>": <VALUE>
@@ -91,7 +91,7 @@ Feature: Patch user
 
   Scenario: Update a user with unexpected error
     Given "user_account" table is dropped
-    When PATCH "/users/1"
+    When PATCH "/users/10ba038e-48da-487b-96e8-8d3b99b6d18a"
       """
       {
         "bio": "Gray fox! It can't be!"

--- a/service/src/handlers/users.js
+++ b/service/src/handlers/users.js
@@ -5,6 +5,7 @@ const bcrypt = require('bcrypt');
 const boom = require('boom');
 const bounce = require('bounce');
 const joi = require('joi');
+const uuidv4 = require('uuid/v4');
 
 const {enforceSelfActionOnly} = require('../utils/user');
 const {getTokenFromRequest} = require('../utils/request');
@@ -64,7 +65,7 @@ users.patch.config = {
 };
 
 users.patch.handler = async (request, h) => {
-  const id = parseInt(getTokenFromRequest(request).id);
+  const {id} = getTokenFromRequest(request);
 
   if (_.isEmpty(request.payload)) return h.response().code(200);
 
@@ -101,6 +102,7 @@ users.post.handler = async (request, h) => {
 
   const userObject = {
     email,
+    id: uuidv4(),
     password: hashedPassword
   };
 

--- a/service/src/migrations/20170827222619_init.js
+++ b/service/src/migrations/20170827222619_init.js
@@ -1,7 +1,7 @@
 exports.up = knex => {
   return knex.schema.createTable('user_account', (table) => {
     table
-      .increments('id')
+      .uuid('id')
       .primary();
 
     table

--- a/service/src/migrations/20170827222619_init.js
+++ b/service/src/migrations/20170827222619_init.js
@@ -2,6 +2,8 @@ exports.up = knex => {
   return knex.schema.createTable('user_account', (table) => {
     table
       .uuid('id')
+      .unique()
+      .index()
       .primary();
 
     table

--- a/service/src/migrations/__tests__/20170827222619_init.test.js
+++ b/service/src/migrations/__tests__/20170827222619_init.test.js
@@ -1,6 +1,7 @@
 const initialMigrations = require('./../20170827222619_init');
 const rootRequire = require('app-root-path').require;
 const sinon = require('sinon');
+const uuidv4 = require('uuid/v4');
 
 const {getKnexConnection} = rootRequire('src/utils/test_utils');
 const knex = getKnexConnection();
@@ -35,10 +36,11 @@ describe('Initial Migration', function() {
 
     context('and when adding a default user_account', function() {
       const email = '( ͡° ͜ʖ ͡°)';
+      const id = uuidv4();
       const password = 'Light salt, please...';
 
       before(async function() {
-        await knex('user_account').insert({email, password});
+        await knex('user_account').insert({id, email, password});
       });
 
       it('populates default fields properly', async function() {
@@ -47,7 +49,7 @@ describe('Initial Migration', function() {
           bio: null,
           createDate: now,
           email,
-          id: 1,
+          id,
           modifyDate: now,
           password
         });

--- a/service/src/utils/user.js
+++ b/service/src/utils/user.js
@@ -4,8 +4,8 @@ const {getTokenFromRequest} = require('./request');
 const userUtils = {};
 
 userUtils.enforceSelfActionOnly = (request, h) => {
-  const userIdFromToken = parseInt(getTokenFromRequest(request).id);
-  const userIdFromRequest = parseInt(request.params.id);
+  const userIdFromToken = getTokenFromRequest(request).id;
+  const userIdFromRequest = request.params.id;
 
   if (userIdFromRequest !== userIdFromToken) {
     return boom.forbidden();


### PR DESCRIPTION
## Description
Given that Monarch may eventually move away from a monolithic architecture,
we'll benefit from having a guarantee of uniqueness across shards or services.
We also want to avoid any possible attack vectors we may incur by folks
trying to estimate the count of any particular table.

To solve both problems, we're going to begin using UUIDs for all primary keys.

 ## Changes
* Use `uuid` for `user` table primary key
* Update `user` resource endpoints to parse `id` as a string, not an integer

 ## Considerations
Really need to ensure that we didn't forget any parseInt calls around the `id`.
There was a bug in the `enforceSelfActionOnly` function where you could potentially
have two separate ids that would be parsed as the same integer, i.e. two different
uuids starting with `80`. Could use a good test here, but really not sure what that
test would look like other than ensuring it's actually a uuid.

![](https://media.giphy.com/media/JUTrT9s8XCBmo/giphy.gif)