### PR TITLE
Remove "I" from all features

### DIFF
--- a/service/src/features/auth/login.feature
+++ b/service/src/features/auth/login.feature
@@ -4,7 +4,7 @@ Feature: Login
   I want to be able to log in using a username and password.
 
   Background:
-    Given I seed "user_account"
+    Given the database is seeded with "user_account"
 
 
   @StubDate

--- a/service/src/features/auth/unauthorized_routes.feature
+++ b/service/src/features/auth/unauthorized_routes.feature
@@ -1,7 +1,7 @@
 Feature: Unauthorized routes
 
   As a user of the Monarch service,
-  When I don't have a token,
+  When I'm not authenticated,
   I want to be denied access to all relevant endpoints.
 
   Scenario Outline: GET or DELETE Request without token

--- a/service/src/features/location/connect.feature
+++ b/service/src/features/location/connect.feature
@@ -2,7 +2,7 @@
 # TODO: Add to unauthorized routes
 Feature: Connect users with sidekicks within a radius
 
-  As a user,
+  As a user of the Monarch service,
   I want to be able to find a sidekick,
   So I can have someone to help provide me with advice,
   resource information, and moral support.

--- a/service/src/features/location/connect.feature
+++ b/service/src/features/location/connect.feature
@@ -8,7 +8,7 @@ Feature: Connect users with sidekicks within a radius
   resource information, and moral support.
 
   Background:
-    Given I get a token
+    Given a valid, authenticated token is obtained
 
 
   Scenario: Match a user with a sidekick within 50 miles

--- a/service/src/features/location/search.feature
+++ b/service/src/features/location/search.feature
@@ -6,7 +6,7 @@ Feature: User can search for a location
   To enable my access to resources.
 
   Background:
-    Given I seed "user_account"
+    Given the database is seeded with "user_account"
     And a valid, authenticated token is obtained
 
   Scenario: Find a location

--- a/service/src/features/location/search.feature
+++ b/service/src/features/location/search.feature
@@ -7,7 +7,7 @@ Feature: User can search for a location
 
   Background:
     Given I seed "user_account"
-    And I get a token
+    And a valid, authenticated token is obtained
 
   Scenario: Find a location
     When POST "/location/search"

--- a/service/src/features/location/search.feature
+++ b/service/src/features/location/search.feature
@@ -1,9 +1,8 @@
 Feature: User can search for a location
 
-  As a user,
+  As a user of the Monarch service,
   I want a list of location suggestions,
-  So Monarch can store my location,
-  To enable my access to resources.
+  So Monarch can store my general location to connect me with resources.
 
   Background:
     Given the database is seeded with "user_account"

--- a/service/src/features/step_definitions/database.js
+++ b/service/src/features/step_definitions/database.js
@@ -11,7 +11,7 @@ When('{string} table is dropped', async function(tableName) {
   await this.knex.schema.dropTable(tableName);
 });
 
-When('I seed {string}', async function(seedFilename) {
+When('the database is seeded with {string}', async function(seedFilename) {
   const pathToSeed = path.join('env', process.env.NODE_ENV, 'seeds', seedFilename);
   const seedFunction = rootRequire(pathToSeed).seed;
   await seedFunction(this.knex);

--- a/service/src/features/step_definitions/token.js
+++ b/service/src/features/step_definitions/token.js
@@ -8,7 +8,7 @@ const isTokenActive = token => {
   return (exp * 1000) > (Date.now() - (60 * 1000));
 };
 
-When('I get a token', async function() {
+When('a valid, authenticated token is obtained', async function() {
   if (isTokenActive(this.token)) return this.token;
 
   const url = this.utils.getRequestUrl('/login');

--- a/service/src/features/step_definitions/user.js
+++ b/service/src/features/step_definitions/user.js
@@ -9,12 +9,12 @@ Given('{ordinalInt} user matches', async function(id, json) {
   if (userResultMatchesPattern) { throw new Error(userResultMatchesPattern); }
 });
 
-Given('I store the {ordinalInt} user', async function(id) {
+Given('a comparison of the {ordinalInt} user', async function(id) {
   const [user] = await this.knex('user_account').select().where({id});
   this.activeUser = user;
 });
 
-Then('{ordinalInt} user remains unchanged', async function(id) {
+Then('{ordinalInt} user has not changed', async function(id) {
   const [user] = await this.knex('user_account').select().where({id});
   expect(user).to.eql(this.activeUser);
 });

--- a/service/src/features/users/delete.feature
+++ b/service/src/features/users/delete.feature
@@ -5,7 +5,7 @@ Feature: Delete user
 
   Background:
     Given I seed "user_account"
-    And I get a token
+    And a valid, authenticated token is obtained
 
 
   Scenario: Delete self

--- a/service/src/features/users/delete.feature
+++ b/service/src/features/users/delete.feature
@@ -4,7 +4,7 @@ Feature: Delete user
   I want to be able to delete a user.
 
   Background:
-    Given I seed "user_account"
+    Given the database is seeded with "user_account"
     And a valid, authenticated token is obtained
 
 

--- a/service/src/features/users/get.feature
+++ b/service/src/features/users/get.feature
@@ -5,7 +5,7 @@ Feature: Get user
 
   Background:
     Given I seed "user_account"
-    And I get a token
+    And a valid, authenticated token is obtained
 
 
   Scenario: Get self

--- a/service/src/features/users/get.feature
+++ b/service/src/features/users/get.feature
@@ -4,7 +4,7 @@ Feature: Get user
   I want to be able to get my information.
 
   Background:
-    Given I seed "user_account"
+    Given the database is seeded with "user_account"
     And a valid, authenticated token is obtained
 
 

--- a/service/src/features/users/patch.feature
+++ b/service/src/features/users/patch.feature
@@ -5,7 +5,7 @@ Feature: Patch user
 
   Background:
     Given I seed "user_account"
-    And I get a token
+    And a valid, authenticated token is obtained
 
 
   Scenario: Update self

--- a/service/src/features/users/patch.feature
+++ b/service/src/features/users/patch.feature
@@ -4,7 +4,7 @@ Feature: Patch user
   I want to be able to update my information.
 
   Background:
-    Given I seed "user_account"
+    Given the database is seeded with "user_account"
     And a valid, authenticated token is obtained
 
 

--- a/service/src/features/users/patch.feature
+++ b/service/src/features/users/patch.feature
@@ -35,13 +35,13 @@ Feature: Patch user
 
 
   Scenario: Update self with empty object
-    Given I store the 1st user
+    Given a comparison of the 1st user
     When PATCH "/users/1"
       """
       {}
       """
     Then response status code is 200
-    And 1st user remains unchanged
+    And 1st user has not changed
 
 
   Scenario Outline: Update self with invalid payload


### PR DESCRIPTION
## Description
Decided to remove I to create consistency in steps. Usually feels redundant
to me and it's too user oriented when not everything is necessarily a user.
From what I've read, it's also considered best practice.

## Changes
* Reword all step_definitions to remove use of first-person

![](https://media.giphy.com/media/b7W5Q0knnRRlK/giphy.gif)